### PR TITLE
Change to using UTC time stamps, Add TTL to keys

### DIFF
--- a/RateLimit.Redis/Decepticon.RateLimit.Redis.csproj
+++ b/RateLimit.Redis/Decepticon.RateLimit.Redis.csproj
@@ -19,7 +19,7 @@ Donate via Paypal: dekcodeofficial@gmail.com</Description>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReleaseNotes></PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RateLimit.Redis/Helpers/DateTimeHelpers.cs
+++ b/RateLimit.Redis/Helpers/DateTimeHelpers.cs
@@ -17,7 +17,7 @@ namespace Decepticon.RateLimit.Redis.Helpers
         public static DateTime UnixTimeStampToDateTime(double unixTimeStampInSeconds)
         {
             // Unix timestamp is seconds past epoch
-            return _Epoch.AddSeconds(unixTimeStampInSeconds).ToLocalTime();
+            return _Epoch.AddSeconds(unixTimeStampInSeconds).ToUniversalTime();
         }
     }
 }


### PR DESCRIPTION
We noticed a bug in the calculation in the Throttling path here. When running on a non-utc server, the ToLocalTime incorrectly set a unix timestamp (UTC based) as a local time, causing the ticks value to be incorrect. In our case NZ, the ticks would be in the future.

Also added TTL to keys, that expires after the bucket would have been completely refilled.